### PR TITLE
Modify roca skill score names

### DIFF
--- a/src/functional/cca.py
+++ b/src/functional/cca.py
@@ -275,10 +275,10 @@ def canonical_correlation_analysis(
     two_afc.name = 'two_alternative_forced_choice'
     roc_below = open_cptdataset(str(cpt.outputs['roc_below'].absolute()) + '.txt') 
     roc_below = getattr(roc_below, [i for i in roc_below.data_vars][0])
-    roc_below.name = 'roc_area_under_curve'
+    roc_below.name = 'roc_area_below_normal'
     roc_above = open_cptdataset(str(cpt.outputs['roc_above'].absolute()) + '.txt')
     roc_above = getattr(roc_above, [i for i in roc_above.data_vars][0])
-    roc_above.name = 'roc_area_above_curve'
+    roc_above.name = 'roc_area_above_normal'
     skill_values = [pearson, spearman, two_afc, roc_below, roc_above]
     skill_values = xr.merge(skill_values).mean('Mode')
 

--- a/src/functional/mlr.py
+++ b/src/functional/mlr.py
@@ -258,10 +258,10 @@ def multiple_regression(
     two_afc.name = 'two_alternative_forced_choice'
     roc_below = open_cptdataset(str(cpt.outputs['roc_below'].absolute()) + '.txt') 
     roc_below = getattr(roc_below, [i for i in roc_below.data_vars][0])
-    roc_below.name = 'roc_area_under_curve'
+    roc_below.name = 'roc_area_below_normal'
     roc_above = open_cptdataset(str(cpt.outputs['roc_above'].absolute()) + '.txt')
     roc_above = getattr(roc_above, [i for i in roc_above.data_vars][0])
-    roc_above.name = 'roc_area_above_curve'
+    roc_above.name = 'roc_area_above_normal'
     skill_values = [pearson, spearman, two_afc, roc_below, roc_above]
     skill_values = xr.merge(skill_values).mean('Mode')
     return hcsts, fcsts, skill_values

--- a/src/functional/pcr.py
+++ b/src/functional/pcr.py
@@ -261,10 +261,10 @@ def principal_components_regression(
     two_afc.name = 'two_alternative_forced_choice'
     roc_below = open_cptdataset(str(cpt.outputs['roc_below'].absolute()) + '.txt') 
     roc_below = getattr(roc_below, [i for i in roc_below.data_vars][0])
-    roc_below.name = 'roc_area_under_curve'
+    roc_below.name = 'roc_area_below_normal'
     roc_above = open_cptdataset(str(cpt.outputs['roc_above'].absolute()) + '.txt')
     roc_above = getattr(roc_above, [i for i in roc_above.data_vars][0])
-    roc_above.name = 'roc_area_above_curve'
+    roc_above.name = 'roc_area_above_normal'
     skill_values = [pearson, spearman, two_afc, roc_below, roc_above]
     skill_values = xr.merge(skill_values).mean('Mode')
 


### PR DESCRIPTION
Fixed bug in names of ROC skill scores in cca.py, pcr.py & mlr.py (same change in each).
Simple name changes.
